### PR TITLE
feat: 카트 업데이트

### DIFF
--- a/order-api/src/main/java/com/zerobase/cms/order/application/CartApplication.java
+++ b/order-api/src/main/java/com/zerobase/cms/order/application/CartApplication.java
@@ -36,6 +36,13 @@ public class CartApplication {
         return cartService.addCart(customerId, form);
     }
 
+    public Cart updateCart(Long customerId, Cart cart) {
+        // 실질적으로 변하는 데이터
+        // 상품의 삭제, 수량 변경
+        cartService.putCart(customerId, cart);
+        return getCart(customerId);
+    }
+
     // 1. 장바구니에 상품을 추가했다.
     // 2. 상품의 가격이나 수량이 변동된다.
     public Cart getCart(Long customerId) {

--- a/order-api/src/main/java/com/zerobase/cms/order/controller/CustomerCartController.java
+++ b/order-api/src/main/java/com/zerobase/cms/order/controller/CustomerCartController.java
@@ -32,4 +32,10 @@ public class CustomerCartController {
             @RequestHeader(name = "X-AUTH-TOKEN") String token) {
         return ResponseEntity.ok(cartApplication.getCart(provider.getUserVo(token).getId()));
     }
+
+    @GetMapping
+    public ResponseEntity<Cart> updateCart(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token, @RequestBody Cart cart) {
+        return ResponseEntity.ok(cartApplication.updateCart(provider.getUserVo(token).getId(), cart));
+    }
 }


### PR DESCRIPTION
Changes
---
카트 조회 로직을 재사용하여 코드의 생산성을 높임.
기존 카트 조회 로직에 가격과 수량, 상품의 삭제 등을 체크하는 로직이 이미 존재해, 이를 호출하여 에러 메세지와 카트의 내용을 업데이트하는 것으로 적용함. 